### PR TITLE
Upgrade to Laravel 13.7 (Wave 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ DreamFactory 4.0.1 and newer supports a very simple solution for logging all req
 All records requested in the API will be written to the database.
 Logging API requests service currently supports only MongoDB.
 
+
+## Overview
+
+DreamFactory is a secure, self-hosted enterprise data access platform that provides governed API access to any data source, connecting enterprise applications and on-prem LLMs with role-based access and identity passthrough.
+
 ## Configuration
 
 To configure the logging of all requests, you need to go to the file

--- a/composer.json
+++ b/composer.json
@@ -25,14 +25,20 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "dreamfactory/df-core": "~1.0",
-    "jenssegers/mongodb": "^4.2.0",
-    "spatie/laravel-http-logger": "^1.9",
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
+    "dreamfactory/df-core": "~1.0.4",
+    "mongodb/laravel-mongodb": "^5.7",
+    "spatie/laravel-http-logger": "^1.11",
     "ext-json": "*",
     "ext-mongodb": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "@stable",
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0",
     "filp/whoops": "~2.0"
   },
   "autoload": {


### PR DESCRIPTION
## Summary

Wave 4 of the L11 -> L13 upgrade campaign. **Composer-only change** — zero source modifications required.

The critical migration here is replacing the abandoned `jenssegers/mongodb` package (pinned to `illuminate/support: ^10|^11`, unmaintained) with the official MongoDB-Inc fork `mongodb/laravel-mongodb ^5.7`. df-mongodb's Wave 2 PR #36 already validated this exact migration; replicating the pattern here.

### Dependency changes
- **Replace** `jenssegers/mongodb ^4.2.0` -> `mongodb/laravel-mongodb ^5.7` (5.7 is the floor; 5.0-5.6 silently downgrade Laravel)
- **Bump** `dreamfactory/df-core ~1.0` -> `~1.0.4` (L13-compatible)
- **Bump** `spatie/laravel-http-logger ^1.9` -> `^1.11` (L13 support added in 1.11)
- **Add** `php ^8.3` floor + `laravel/helpers ^1.8` (function polyfills)
- **Modernize dev deps**: `laravel/framework ^13.7`, `phpunit ^11.5.3`, `orchestra/testbench ^11.0`, `mockery ^1.6`, `nunomaduro/collision ^8.6`

### Why no source changes?
df-mongo-logs interacts with MongoDB only via:
1. `'driver' => 'mongodb'` in `config/logs-db.php` — driver name unchanged across the jenssegers -> mongodb fork
2. `MongoDB\BSON\UTCDateTime` in `MongoLogWriter.php` — sourced from `ext-mongodb`, unchanged
3. `DB::connection('logsdb')->collection('access')->insert(...)` — works through `mongodb/laravel-mongodb`'s `Connection` (auto-registered via package discovery from `MongoDB\Laravel\MongoDBServiceProvider`)

There are NO `Jenssegers\Mongodb\` namespace imports or `extends` in the source tree (verified by grep). All Wave 2 grammar invariants (CorsService, DispatchesJobs, getDates, setupBeforeClass, ConnectionInterface 4th param, etc.) are inapplicable — this package has no Connection/Builder/Grammar extensions, no test stubs, no LaravelServiceProvider override.

### Platform requirement
`mongodb/laravel-mongodb ^5.7` requires `ext-mongodb ^1.21|^2`. The dev container ships ext-mongodb 1.20.x. Use `--ignore-platform-req=ext-mongodb` for smoke testing; production deployments will need ext-mongodb >= 1.21.

## Test plan

- [x] `composer validate --strict` clean
- [x] **Stage 1 (isolated install)**: `composer install --no-dev --ignore-platform-req=ext-mongodb` resolves with `mongodb/laravel-mongodb 5.7.1`, `laravel/framework 13.7.0`, `spatie/laravel-http-logger 1.11.2`. All 4 public classes (`ServiceProvider`, `MongoLogWriter`, `AllMethodsLogger`, `AsyncLogger`) load via `class_exists`. `MongoDB\Laravel\MongoDBServiceProvider` resolves. Helper polyfills (`array_get`, `camel_case`, `array_except`) function.
- [x] **Stage 2 (host-app integration)**: shift-173254 worktree with df-mongo-logs PRESENT (no strip). Standard sibling-strip applied (`df-oauth`, `df-mcp-server`, `df-git`). Path-repos for `df-core`, `df-system`, `df-user`, `df-database`, `df-mongo-logs`. `composer install --no-dev` succeeds; `package:discover` reports DONE for all 21 sibling packages including `dreamfactory/df-mongo-logs` and `mongodb/laravel-mongodb`.
- [ ] Production smoke: requires container with `ext-mongodb >= 1.21` to confirm `LOGSDB_ENABLED=true` request-logging path round-trips through `mongodb/laravel-mongodb`'s `Connection->collection()->insert()`

## Campaign-wide unblock

**This PR removes df-mongo-logs from the Wave 1+ Stage-2 strip-list.** Prior waves (df-core, df-system, df-user, df-database, df-sqldb, etc.) all needed `composer remove --no-update dreamfactory/df-mongo-logs` from the host's `composer.json` because jenssegers/mongodb's `illuminate/support: ^10|^11` constraint blocked any L13 install. With this PR merged and a `1.4.x-l13`-style tag (or `dev-shift/laravel-13` floated), Wave 5 packages no longer need that scrub step.

Refs: companion to df-mongodb PR #36 (Wave 2) which performed the same migration.