### PR TITLE
feat: migrate jenssegers/mongodb → mongodb/laravel-mongodb (df-commercial 7.6.0 blocker)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "authors": [
     {
-      "name":  "DreamFactory Team",
+      "name": "DreamFactory Team",
       "email": "code@dreamfactory.com"
     }
   ],
@@ -26,10 +26,10 @@
   "prefer-stable": true,
   "require": {
     "dreamfactory/df-core": "~1.0",
-    "jenssegers/mongodb": "^4.2.0",
-    "spatie/laravel-http-logger": "^1.9",
     "ext-json": "*",
-    "ext-mongodb": "*"
+    "ext-mongodb": "*",
+    "mongodb/laravel-mongodb": "^5.7",
+    "spatie/laravel-http-logger": "^1.9"
   },
   "require-dev": {
     "phpunit/phpunit": "@stable",


### PR DESCRIPTION
## Migrate jenssegers/mongodb → mongodb/laravel-mongodb

### Why
`jenssegers/mongodb` was renamed to `mongodb/laravel-mongodb` in 2024 and the original package is deprecated (composer prints an abandoned-package warning). The new package uses the same connection driver name (`mongodb`) and the same `DB::connection()` / `Schema::connection()` facade API, so this is a one-line composer.json swap for df-mongo-logs.

### Scope of change
`composer.json` only — `jenssegers/mongodb: ^4.2.0` → `mongodb/laravel-mongodb: ^5.7`.

The package source code does not import any jenssegers classes (verified via grep across all PHP files in `src/`, `config/`, `database/migrations/`). Concrete usages are:
- `MongoDB\BSON\UTCDateTime` — ext-mongodb, survives the swap
- `Spatie\HttpLogger\Middlewares\HttpLogger` — unrelated dependency
- `DB::connection('logsdb')` / `Schema::connection('logsdb')` — generic Laravel API

### Why right now
This is required to unblock the **dreamfactory/df-commercial 7.6.0 release**.

df-mongodb **0.22.1** (the latest tag) switched its connection driver to `mongodb/laravel-mongodb ^5.7`. df-mongo-logs **1.3.0** still pins `jenssegers/mongodb ^4.2.0`. The two packages declare a `replaces` relationship and cannot coexist — every silver/silver-plus-*/gold/hosted-wizard tier carries both, so composer can't resolve the dependency graph.

### Laravel compatibility
`mongodb/laravel-mongodb ^5.7` supports `illuminate/* ^10|^11|^12|^13` — no change in our framework support matrix.

### Suggested next step
Once this is merged, cut a **1.4.0** tag of df-mongo-logs so df-commercial 7.6.0's composer.lock regeneration can pin to it.

### Test plan
- [ ] `composer install` succeeds in a host app on Laravel 11
- [ ] `LOGSDB_ENABLED=true` actually writes a log row to Mongo
- [ ] `php artisan migrate` against the `logsdb` connection still creates the `access` collection
